### PR TITLE
Fix #5, #3 and bdprochot_on.sh

### DIFF
--- a/bdprochot_off.sh
+++ b/bdprochot_off.sh
@@ -6,7 +6,7 @@ sudo modprobe msr
 r=`sudo rdmsr 0x1FC`
 #echo $r > temp
 s='0x'$r'' 
-f=$(($s&0xFFFFE))
-sudo wrmsr 0x1FC "obase=16;$f"|bc
-echo "$r"" write to ""reg 0x1FC" 
+f=$(($s&0xFFFFFE))
+sudo wrmsr 0x1FC $f
+echo "$f"" write to ""reg 0x1FC" 
 echo "BD PROCHOT off."

--- a/bdprochot_on.sh
+++ b/bdprochot_on.sh
@@ -2,11 +2,10 @@
 #  
 
 sudo modprobe msr 
-# r=`sudo rdmsr 0x1FC`
-# s='0x'$r'' 
-# f=$(($s|0x00001))
+r=`sudo rdmsr 0x1FC`
+s='0x'$r'' 
+f=$(($s|0x1))
 
-# sudo wrmsr 0x1FC "obase=16;$f"|bc
-sudo wrmsr 0x1FC 4005d
+sudo wrmsr 0x1FC $f
 
 echo "BD PROCHOT on."


### PR DESCRIPTION
Fix #5 by and with 0xFFFFFE instead of 0xFFFFE. This is needed on some platform such as intel core i7 1165G7. This will not influence those working platforms since and with operation will ignore the superfluous F. 

Fix #3 by using plain decimal value when write back to reg. For more background, see #3.

Fix the output of bdprochot_off.sh. It is the $f variable instead of the $s variable that is written to the reg, so I change $s to $f in the output. 

Fix the bdprochot_on.sh. The old script write a fix value to the reg, which doesn't work for most of the platforms. I change it to calculate the correct value so that it can be used on any platform.

I have tested the scripts on intel core i7 1165G7. The original value of reg 0x1FC is 0x24005b. After running bdprochot_off.sh, it changed to 0x24005a, showing that the bit[0] had been set to 0. Then run bdprochot_on.sh and it recovered to 0x24005b.